### PR TITLE
Fix RTL offscreen mixin to not override most offscreen rules

### DIFF
--- a/d2l-offscreen-shared-styles.html
+++ b/d2l-offscreen-shared-styles.html
@@ -3,17 +3,21 @@
 	<template>
 		<style>
 			:host {
-				--d2l-offscreen: {
+				--d2l-offscreen-ltr-rtl-shared: {
 					position: absolute !important;
-					left: -10000px;
 					overflow: hidden;
 					width: 1px;
 					height: 1px;
 					white-space: nowrap;
+				}
+				--d2l-offscreen: {
+					@apply(--d2l-offscreen-ltr-rtl-shared);
+					left: -10000px;
 				};
 			}
 			:host-context([dir="rtl"]) {
 				--d2l-offscreen: {
+					@apply(--d2l-offscreen-ltr-rtl-shared);
 					left: 0;
 					right: -10000px;
 				};

--- a/d2l-offscreen-shared-styles.html
+++ b/d2l-offscreen-shared-styles.html
@@ -18,7 +18,6 @@
 			:host-context([dir="rtl"]) {
 				--d2l-offscreen: {
 					@apply(--d2l-offscreen-ltr-rtl-shared);
-					left: 0;
 					right: -10000px;
 				};
 			}


### PR DESCRIPTION
So in my haste Friday I didn't realize that the RTL offscreen styles wern't really working... I just solved the horizontal scrolling issue.  What's happning is that you can't dynamically add to a mixin like I thought you can.

So I've refactored to pull from a shared mixin for rtl and ltr.  I think it is fine. 

There is an open Polymer issue that I think is related to this here: https://github.com/Polymer/polymer/issues/2268

@dlockhart  I think I'm going to merge this but let me know if you think there is a better approach and I can follow up!