### PR TITLE
Use hybrid versions of iron-component-page and iron-demo-helpers.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,18 +21,14 @@
   },
   "devDependencies": {
     "d2l-typography": "^6.0.0",
-    "iron-component-page": "1 - 2",
-    "iron-demo-helpers": "1 - 2",
+    "iron-component-page": "^2.0.0",
+    "iron-demo-helpers": "^2.0.0",
     "web-component-tester": "^6.0.0"
   },
   "variants": {
     "1.x": {
       "dependencies": {
         "polymer": "^1.9.1"
-      },
-      "devDependencies": {
-        "iron-component-page": "^1.1.9",
-        "iron-demo-helpers": "^1.2.6"
       },
       "resolutions": {
         "webcomponentsjs": "^0.7"


### PR DESCRIPTION
It turns out that we can use hybrid versions of these too (which if we don't eventually causes version conflicts with our use of iron-iconset-svg elsewhere).  Anyway, we can just use hybrid versions of these.